### PR TITLE
fix: dataset_fields_ids from TypeList to TypeSet

### DIFF
--- a/pkg/providers/datastream/resource_akamai_datastream.go
+++ b/pkg/providers/datastream/resource_akamai_datastream.go
@@ -95,7 +95,7 @@ var datastreamResourceSchema = map[string]*schema.Schema{
 		Description: "The date and time when the stream was created",
 	},
 	"dataset_fields_ids": {
-		Type:     schema.TypeList,
+		Type:     schema.TypeSet,
 		Required: true,
 		Elem: &schema.Schema{
 			Type: schema.TypeInt,
@@ -637,11 +637,11 @@ func resourceDatastreamCreate(ctx context.Context, d *schema.ResourceData, m int
 	}
 	contractID = strings.TrimPrefix(contractID, "ctr_")
 
-	datasetFieldsIDsList, err := tools.GetListValue("dataset_fields_ids", d)
+	datasetFieldsIDsList, err := tools.GetSetValue("dataset_fields_ids", d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	datasetFieldsIDs := InterfaceSliceToIntSlice(datasetFieldsIDsList)
+	datasetFieldsIDs := InterfaceSliceToIntSlice(datasetFieldsIDsList.List())
 
 	emailIDsList, err := tools.GetListValue("email_ids", d)
 	if err != nil {
@@ -931,11 +931,11 @@ func updateStream(ctx context.Context, client datastream.DS, logger log.Interfac
 			return err
 		}
 
-		datasetFieldsIDsList, err := tools.GetListValue("dataset_fields_ids", d)
+		datasetFieldsIDsList, err := tools.GetSetValue("dataset_fields_ids", d)
 		if err != nil {
 			return err
 		}
-		datasetFieldsIDs := InterfaceSliceToIntSlice(datasetFieldsIDsList)
+		datasetFieldsIDs := InterfaceSliceToIntSlice(datasetFieldsIDsList.List())
 
 		emailIDsList, err := tools.GetListValue("email_ids", d)
 		if err != nil {


### PR DESCRIPTION
Change dataset_fields_ids type from shema.TypeList to schema.TypeSet to fix idempotency issue when using multiple elements.

Wen creating the stream with multiple dataset_fields_ids, the order doesn't matter. However, since it's a list, after the read the different order could make terraform list some changes when there aren't:

```
  # akamai_datastream.this will be updated in-place
  ~ resource "akamai_datastream" "this" {
      ~ dataset_fields_ids = [
            # (1 unchanged element hidden)
            1002,
          - 1100,
            1005,
            # (9 unchanged elements hidden)
            1017,
          - 2001,
          - 2002,
          - 2003,
          - 2004,
          - 2006,
          - 2008,
          - 2009,
            1019,
            # (2 unchanged elements hidden)
            1032,
          - 1037,
          - 2005,
            1033,
          + 1037,
            1068,
          + 1100,
            1102,
            1103,
          + 2001,
          + 2002,
          + 2003,
          + 2004,
          + 2005,
          + 2006,
            2007,
          + 2008,
          + 2009,
            2010,
        ]
        # (17 unchanged attributes hidden)


        splunk_connector {
          # At least one attribute in this block is (or was) sensitive,
          # so its contents will not be displayed.
        }
        # (1 unchanged block hidden)
```
This PR is a proposed solution to remove the dependency on the order, which isn't in control of the end user, by changing the type from list to set.